### PR TITLE
Implement database unit of work

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -19,6 +19,9 @@ import { AuthModule } from "./modules/auth/auth.module";
             playground: true,
             sortSchema: true,
             autoSchemaFile: join(process.cwd(), "schema.graphql"),
+            // https://github.com/nestjs/nest/issues/1905#issuecomment-479431252
+            // @ts-ignore
+            context: ({ req }) => ({ req }),
         }),
         DrizzleModule.forRootAsync({
             imports: [ConfigModule],

--- a/apps/api/src/app.resolver.spec.ts
+++ b/apps/api/src/app.resolver.spec.ts
@@ -1,3 +1,4 @@
+import { ContextIdFactory } from "@nestjs/core";
 import { Test, TestingModule } from "@nestjs/testing";
 import { AppModule } from "./app.module";
 import { AppResolver } from "./app.resolver";
@@ -13,7 +14,12 @@ describe("AppService", () => {
             imports: [AppModule],
         }).compile();
 
-        appResolver = app.get<AppResolver>(AppResolver);
+        const contextId = ContextIdFactory.create();
+        jest.spyOn(ContextIdFactory, "getByRequest").mockImplementation(
+            () => contextId,
+        );
+
+        appResolver = await app.resolve(AppResolver, contextId);
     });
 
     describe("root", () => {

--- a/apps/api/src/drizzle/drizzle.module.ts
+++ b/apps/api/src/drizzle/drizzle.module.ts
@@ -1,4 +1,5 @@
 import { Global, Module } from "@nestjs/common";
+import { APP_INTERCEPTOR } from "@nestjs/core";
 import { Pool } from "pg";
 import { DatabaseOptions } from "./database-options";
 import {
@@ -7,6 +8,7 @@ import {
     DATABASE_OPTIONS,
 } from "./drizzle.module-definition";
 import { DrizzleService } from "./drizzle.service";
+import { TransactionInterceptor } from "./transaction.interceptor";
 
 @Global()
 @Module({
@@ -21,6 +23,10 @@ import { DrizzleService } from "./drizzle.service";
                     database: databaseOptions.database,
                 });
             },
+        },
+        {
+            provide: APP_INTERCEPTOR,
+            useClass: TransactionInterceptor,
         },
     ],
     exports: [DrizzleService],

--- a/apps/api/src/drizzle/drizzle.service.ts
+++ b/apps/api/src/drizzle/drizzle.service.ts
@@ -14,7 +14,8 @@ export class DrizzleService {
     ) {}
 
     public get db(): NodePgDatabase<typeof schema> {
-        const req = this.context.req;
-        return req[DRIZZLE_DATABASE_KEY] ?? drizzle(this.pool, { schema });
+        return (
+            this.context[DRIZZLE_DATABASE_KEY] ?? drizzle(this.pool, { schema })
+        );
     }
 }

--- a/apps/api/src/drizzle/drizzle.service.ts
+++ b/apps/api/src/drizzle/drizzle.service.ts
@@ -1,14 +1,20 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Scope } from "@nestjs/common";
+import { CONTEXT } from "@nestjs/graphql";
 import { NodePgDatabase, drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import { CONNECTION_POOL } from "./drizzle.module-definition";
 import * as schema from "./schema";
+import { DRIZZLE_DATABASE_KEY } from "./transaction.interceptor";
 
-@Injectable()
+@Injectable({ scope: Scope.REQUEST })
 export class DrizzleService {
-    public db: NodePgDatabase<typeof schema>;
+    constructor(
+        @Inject(CONNECTION_POOL) private readonly pool: Pool,
+        @Inject(CONTEXT) private readonly context: any,
+    ) {}
 
-    constructor(@Inject(CONNECTION_POOL) private readonly pool: Pool) {
-        this.db = drizzle(this.pool, { schema });
+    public get db(): NodePgDatabase<typeof schema> {
+        const req = this.context.req;
+        return req[DRIZZLE_DATABASE_KEY] ?? drizzle(this.pool, { schema });
     }
 }

--- a/apps/api/src/drizzle/transaction.interceptor.ts
+++ b/apps/api/src/drizzle/transaction.interceptor.ts
@@ -1,0 +1,50 @@
+import {
+    CallHandler,
+    ExecutionContext,
+    Inject,
+    Injectable,
+    NestInterceptor,
+} from "@nestjs/common";
+import { GqlExecutionContext } from "@nestjs/graphql";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { Observable, catchError, switchMap, throwError } from "rxjs";
+import { CONNECTION_POOL } from "./drizzle.module-definition";
+import * as schema from "./schema";
+
+export const DRIZZLE_DATABASE_KEY = "DRIZZLE_DATABASE";
+
+@Injectable()
+export class TransactionInterceptor implements NestInterceptor {
+    constructor(@Inject(CONNECTION_POOL) private readonly pool: Pool) {}
+
+    async intercept(
+        context: ExecutionContext,
+        next: CallHandler<any>,
+    ): Promise<Observable<any>> {
+        const gqlContext = GqlExecutionContext.create(context);
+        const req = gqlContext.getContext().req;
+
+        const db = drizzle(this.pool, { schema });
+        return db.transaction(async (tx) => {
+            // Attach the transaction to the request object
+            // @ts-ignore
+            req[DRIZZLE_DATABASE_KEY] = tx;
+
+            return next
+                .handle()
+                .pipe(
+                    switchMap(async (data) => {
+                        // If we reach this point, it means the request was successful
+                        // The transaction will be automatically committed
+                        return data;
+                    }),
+                    catchError((error) => {
+                        // If an error occurs, the transaction will be automatically rolled back
+                        return throwError(() => error);
+                    }),
+                )
+                .toPromise();
+        });
+    }
+}


### PR DESCRIPTION
# Problem
A request should create an ACID transaction, that should be committed only when the request finishes successfully. If a request fails (for whatever reason: be it 4xx or 5xx error), the transaction should rollback, effectively preventing any partial writes (e.g., insert queries that span multiple entries or tables) to persist in the database.

## Helpful links (mostly with typeorm)
- https://medium.com/@dev.muhammet.ozen/advanced-transaction-management-with-nestjs-typeorm-43a839363491
- https://stackoverflow.com/questions/77849015/how-to-use-a-transaction-across-multiple-services-in-nestjs
- https://github.com/LuanMaik/nestjs-unit-of-work
- https://github.com/LuanMaik/nestjs-typeorm-transaction-unitOfWork-AsyncLocalStorage
- https://medium.com/@rahulrulz680/unit-of-work-in-repository-pattern-b48a862d06a2

# Solution
- Setup an interceptor (`TransactionInterceptor`) that
  - creates a drizzle transaction upon each request,
  - injects the transaction instance into GraphQL context object (which is shared globally and can be used by any request-scoped provider),
  - calls the route handler,
  - rolls back the transaction if the handler throws an exception,
  - otherwise, commits the transaction.
- Make `DrizzleService` [request-scoped](https://docs.nestjs.com/fundamentals/injection-scopes), which allows it to access GraphQL context object, and consequently access the transaction instance that was created and injected by `TransactionInterceptor`.
- `DrrizleService` should then expose that transaction instance to any provider that wants to use the service.

# Side effects
- Since `DrizzleService` is request-scoped, any provider that depends on it will also be request-scoped (even if it wasn't explicitly decorated with `@Injectable({ scope: Scope.REQUEST })`) [[sauce](https://docs.nestjs.com/fundamentals/injection-scopes#scope-hierarchy)]. Also, because it's a core service that almost all resolvers/services are going to use, that means almost all resolvers/services in our app are going to be request-scoped. This will have a slight performance overhead because request-scoped providers are instantiated every time a request is made to our API and then garbage-collected when the request is finished. This is in contrast to normal providers, which are instantiated once throughout the lifetime of our Nest app. [[sauce](https://docs.nestjs.com/fundamentals/injection-scopes#performance)]
- There's another side effect that stems from the above point, which is the fact that testing now has to be done a little differently (as demonstrated by the changes in `api/src/app.resolver.spec.ts`). This is something I don't fully understand (yet), but here's the [[sauce](https://docs.nestjs.com/fundamentals/testing#testing-request-scoped-instances)] for further reading.